### PR TITLE
Fixes HTML view instance conflicts and debounces formatting

### DIFF
--- a/src/canvas-action.ts
+++ b/src/canvas-action.ts
@@ -4,12 +4,18 @@ import type { Parameters } from './types';
 const instances = new Map();
 let currentComponentId = '';
 
-export function setStoryCanvasHtml(componentId: string, storyId: string, html: string, params: Parameters) {
+export function setStoryCanvasHtml(
+  componentId: string,
+  storyId: string,
+  canvasId: string,
+  html: string,
+  params: Parameters,
+) {
   shouldResetInstances(componentId);
-  const storyData = instances.get(storyId);
+  const storyData = instances.get(canvasId);
   const data = storyData ? { ...storyData, html: html } : { storyId: storyId, params: params, html: html };
 
-  instances.set(storyId, data);
+  instances.set(canvasId, data);
   initToggleButton(storyId, params);
 
   if (storyData?.htmlContainer) {
@@ -17,7 +23,7 @@ export function setStoryCanvasHtml(componentId: string, storyId: string, html: s
   }
 }
 
-export function updateHtmlView(el: HTMLElement, html: string) {
+function updateHtmlView(el: HTMLElement, html: string) {
   el.innerHTML = generateInnerHtml(html);
   bindCopyButton(el);
 }
@@ -65,7 +71,7 @@ export function removeCanvasToggleButton(storyId: string) {
  * This ensures that HTML view state is isolated per component and we're not retaining old data.
  * Side effect: Updates currentComponentId and clears the instances map if a reset occurs.
  */
-export function shouldResetInstances(componentId: string) {
+function shouldResetInstances(componentId: string) {
   if (currentComponentId !== componentId) {
     currentComponentId = componentId;
     instances.clear();
@@ -84,23 +90,24 @@ function createHtmlContainer(storyId: string, story: Element, html: string) {
 }
 
 function initHtmlView(button: HTMLElement) {
+  const canvasId = button.closest('.docs-story')?.querySelector('[id^="story--"][id$="-inner"]')?.id;
   const story = button.closest('.sb-anchor');
   const storyId = story?.id.replace('anchor--', '');
-  const storyData = instances.get(storyId);
+  const storyData = instances.get(canvasId);
 
-  if (!storyId || !story || !storyData) {
+  if (!canvasId || !storyId || !story || !storyData) {
     console.error('Story or storyId not found for HTML view initialization.');
     return;
   }
 
-  const storyHtml = getStoryHtml(storyId);
+  const storyHtml = getStoryHtml(canvasId);
   button.textContent = storyData.params.canvasToggleText.opened || 'Hide HTML';
-  button.dataset.storyId = storyId;
+  button.dataset.canvasId = canvasId;
 
   const htmlContainer = createHtmlContainer(storyId, story, storyHtml);
   bindCopyButton(htmlContainer);
 
-  instances.set(storyId, {
+  instances.set(canvasId, {
     ...storyData,
     htmlContainer: htmlContainer,
   });
@@ -129,15 +136,15 @@ function generateInnerHtml(html: string) {
 	`;
 }
 
-function getStoryHtml(storyId: string) {
-  const storyData = instances.get(storyId);
+function getStoryHtml(canvasId: string) {
+  const storyData = instances.get(canvasId);
   if (!storyData) return '';
 
   return storyData.html;
 }
 
 function reset(button: HTMLElement) {
-  const instance = instances.get(button.dataset.storyId);
+  const instance = instances.get(button.dataset.canvasId);
   button.textContent = instance?.params.canvasToggleText.closed || 'Show HTML';
 
   if (instance) {

--- a/src/withHtml.tsx
+++ b/src/withHtml.tsx
@@ -38,7 +38,7 @@ function render(storyFn: StoryFunction<Renderer>, context: StoryContext, params:
   useEffect(() => {
     if (context.viewMode !== 'docs') return;
 
-    setStoryCanvasHtml(context.componentId, context.id, prettyHtml, params);
+    setStoryCanvasHtml(context.componentId, context.id, context.canvasElement.id, prettyHtml, params);
   }, [prettyHtml]);
 
   return storyFn();


### PR DESCRIPTION
Addresses a bug where multiple instances of the same story, particularly in Storybook Docs mode, would conflict when displaying their HTML. This occurred because all instances shared the same `storyId`, leading to incorrect HTML being shown or overwritten. The fix introduces `context.canvasElement.id` as a unique identifier for each HTML view instance, ensuring correct and isolated display.

Improves the performance of HTML formatting by debouncing the process when the HTML content changes rapidly. This prevents excessive re-renders and redundant web worker calls, especially during dynamic story updates or live editing.

*   Introduces a `debounceDelay` parameter (defaulting to 300ms) to control the delay before formatting.
*   Utilizes `AbortController` to efficiently cancel previous formatting operations if new HTML arrives within the debounce period.
*   Optimizes the `usePrettyHtml` hook to avoid formatting if the HTML content has not changed.
*   Updates Storybook dependencies to `10.3.0-alpha.5`.